### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: "\U0001F41B bug"
+assignees: ''
+
+---
+
+# Summary
+
+## Problem
+
+Describe the immediate problem.
+
+### Impact
+
+What's the impact of this bug?
+
+## Solution
+
+Describe the sort of fix that would solve the issue.
+
+# Detail
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior. For example:
+
+1. Run '...'
+2. Open the Webnative devtools panel
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+Please include a screenshot or screencap if relevant.
+
+**Desktop (please complete the following information):**
+
+ - OS: [e.g. macOS Ventura 13.0.1]
+ - Browser: [e.g. Firefox 108]
+ - Extension version: [e.g. 0.1]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: "\U0001F497 enhancement"
+assignees: ''
+
+---
+
+NB: Feature requests will only be considered if they solve a pain or present a useful refactoring of the code.
+
+# Summary
+
+## Problem
+
+Describe the pain that this feature will solve.
+
+### Impact
+
+Describe the impact of not having this feature.
+
+## Solution
+
+Describe the solution.
+
+# Detail
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Link to issue
+
+Please add a link to any relevant issues/tickets.
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that updates existing functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Comments have been added/updated
+
+Please delete options that are not relevant.
+
+## Test plan (required)
+
+Demonstrate the code is solid.
+
+Which commands did you test with and what are the expected results? Which tests have you added or updated? Do the
+tests cover all of the changes included in this PR?
+
+## Screenshots/Screencaps
+
+Please include a screenshot or screencap that includes any changes made in this PR.


### PR DESCRIPTION
# Description

This PR adds GitHub issue and PR templates to the project.

## Link to issue

Closes #3 

## Type of change

- [x] New feature (non-breaking change that adds functionality

## Test plan (required)

New issue and PR templates should be added after this is merged.
