### PR TITLE
Fix duplicate panels created in Firefox

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -20,7 +20,7 @@
     {
       "matches": [
         "https://*/*",
-        "http://localhost:8080/*"
+        "http://localhost/*"
       ],
       "js": ["src/content/page-load.js"]
     }
@@ -28,7 +28,7 @@
   "devtools_page": "src/devtools/devtools.html",
   "host_permissions": [
     "https://*/*",
-    "http://localhost:8080/*"
+    "http://localhost/*"
   ],
   "permissions": [
     "activeTab",

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -15,7 +15,7 @@
   "devtools_page": "src/devtools/devtools.html",
   "host_permissions": [
     "https://*/*",
-    "<all_urls>"
+    "http://localhost/*"
   ],
   "permissions": [
     "activeTab",

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -12,6 +12,15 @@
   "background": {
     "scripts": [ "src/background/background.js" ]
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*/*",
+        "http://localhost/*"
+      ],
+      "js": ["src/content/page-load.js"]
+    }
+  ],
   "devtools_page": "src/devtools/devtools.html",
   "host_permissions": [
     "https://*/*",

--- a/src/devtools/Panel.svelte
+++ b/src/devtools/Panel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { JsonView } from '@zerodevx/svelte-json-view'
-  import { connection, eventStore } from './devtools'
+  import { connection, eventStore } from './panel'
 
   let selectedEvent = null
   let selectedEventIndex

--- a/src/devtools/panel.js
+++ b/src/devtools/panel.js
@@ -1,4 +1,33 @@
+import browser from 'webextension-polyfill'
+import { writable } from 'svelte/store'
+
 import Panel from '/src/devtools/Panel.svelte'
+
+// STORES
+
+const tabId = browser.devtools.inspectedWindow.tabId
+
+export const connection = writable({ tabId, connected: false, error: null })
+
+export const eventStore = writable([])
+
+function initializeStores(event) {
+  connection.set(event.connection)
+  eventStore.set(event.events)
+}
+
+function updateConnection(event) {
+  connection.set(event)
+}
+
+function updateEvents(event) {
+  eventStore.set(event)
+}
+
+// Stores are synced with store state in devtools.js
+window.initializeStores = initializeStores
+window.updateConnection = updateConnection
+window.updateEvents = updateEvents
 
 
 // RENDER PANEL

--- a/vite.firefox.config.ts
+++ b/vite.firefox.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite'
 import { resolve } from 'path'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-// import manifest from './manifest-firefox.json'
 
 const srcDir = resolve(__dirname, 'src')
 
@@ -10,6 +9,7 @@ const srcDir = resolve(__dirname, 'src')
 export default defineConfig({
   build: {
     emptyOutDir: true,
+    minify: false,
     outDir: resolve(__dirname, 'dist/firefox'),
     rollupOptions: {
       input: {
@@ -34,6 +34,10 @@ export default defineConfig({
         },
         {
           src: 'src/content/content.js',
+          dest: 'src/content',
+        },
+        {
+          src: 'src/content/page-load.js',
           dest: 'src/content',
         }
       ]


### PR DESCRIPTION
# Description

This PR implements the following fixes:

- [x] Prevent the creation of multiple panels
- [x] Add missing page load content script to Firefox
- [x] Generalize `localhost` permissions to all ports

## Link to issue

Closes #16 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Temporarily load the extension into Firefox. Test it with a site that uses Webnative. When inspecting messages, only a single panel should be created.

The connection should remain across page reloads.

The extension should work on any `localhost` port.

