### PR TITLE
Fix not connected status

### DIFF
--- a/src/content/page-load.js
+++ b/src/content/page-load.js
@@ -1,8 +1,10 @@
+chrome.runtime.sendMessage({ id: `${chrome.runtime.id}`, type: 'pageload' })
+
 window.addEventListener('message', (event) => {
   // Reject messages not from ourselves
   if (event.source !== window) return
 
   if (event.data.id === 'webnative-devtools-ready-message') {
-    chrome.runtime.sendMessage({ id: `${chrome.runtime.id}`, type: 'pageload' })
+    chrome.runtime.sendMessage({ id: `${chrome.runtime.id}`, type: 'ready' })
   }
 })

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -168,13 +168,17 @@ function handleBackgroundMessage(message) {
   } else if (message.type === 'pageload') {
     console.log('received page load message', message)
 
+    connectionStore.update(store => ({ ...store, connected: false }))
+  } else if (message.type === 'ready') {
+    console.log('received ready message', message)
+
     // Inject content script if missing
     backgroundPort.postMessage({
       type: 'inject',
       tabId: browser.devtools.inspectedWindow.tabId
     })
-    connect()
 
+    connect()
   } else {
     console.log('received an unknown message type', message)
   }

--- a/src/devtools/panel/icons/X.svelte
+++ b/src/devtools/panel/icons/X.svelte
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="12"
+  height="12"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="white"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="feather feather-x"
+>
+  <line x1="18" y1="6" x2="6" y2="18" />
+  <line x1="6" y1="6" x2="18" y2="18" />
+</svg>


### PR DESCRIPTION
# Description

This PR implements the following features/fixes:

- [x] Set not connected status when Webnative is not available
- [x] Add missing X icon

## Link to issue

Closes #22

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Test plan (required)

The devtools should display "Webnative not connected" in the nav when Webnative is not available.

## Screenshots/Screencaps

<img width="1920" alt="CleanShot 2023-03-27 at 09 35 08@2x" src="https://user-images.githubusercontent.com/7957636/228007118-eeff182a-d817-4713-8905-e400b38bf84f.png">

