### PR TITLE
added hooks to propogate devtools theme change into the panel.

### DIFF
--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -22,8 +22,14 @@ browser.devtools.panels.create(
   let unsubscribeConnectionStore
   let unsubscribeMessageStore
   let unsubscribeNamespaceStore
+  let removeThemeChangeListener
 
   panel.onShown.addListener(panelWindow => {
+
+    panelWindow.setTheme(browser.devtools.panels.themeName)
+
+    browser.devtools.panels.onThemeChanged.addListener(panelWindow.setTheme)
+
     panelWindow.initializeStores({
       connection: getStore(connectionStore),
       messages: getStore(messageStore),
@@ -51,12 +57,17 @@ browser.devtools.panels.create(
     unsubscribeNamespaceStore = namespaceStore.subscribe(store => {
       panelWindow.updateNamespaces(store)
     })
+
+    removeThemeChangeListener = () => {
+      browser.devtools.panels.onThemeChanged.removeListener(panelWindow.setTheme)
+    }
   })
 
   panel.onHidden.addListener(() => {
     unsubscribeConnectionStore()
     unsubscribeMessageStore()
     unsubscribeNamespaceStore()
+    removeThemeChangeListener()
   })
 })
 

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -65,7 +65,6 @@ browser.devtools.panels.create(
     unsubscribeConnectionStore()
     unsubscribeMessageStore()
     unsubscribeNamespaceStore()
-    removeThemeChangeListener()
   })
 })
 

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -27,7 +27,7 @@ browser.devtools.panels.create(
   panel.onShown.addListener(panelWindow => {
 
     /**
-     * on Chrome, themeName can be one of ( defauilt, dark )
+     * on Chrome, themeName can be one of ( default, dark )
      * on Firefox, themeName can be one of ( light, dark )
      */
     panelWindow.setTheme(browser.devtools.panels.themeName)

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -26,9 +26,11 @@ browser.devtools.panels.create(
 
   panel.onShown.addListener(panelWindow => {
 
+    /**
+     * on Chrome, themeName can be one of ( defauilt, dark )
+     * on Firefox, themeName can be one of ( light, dark )
+     */
     panelWindow.setTheme(browser.devtools.panels.themeName)
-
-    browser.devtools.panels.onThemeChanged.addListener(panelWindow.setTheme)
 
     panelWindow.initializeStores({
       connection: getStore(connectionStore),
@@ -57,10 +59,6 @@ browser.devtools.panels.create(
     unsubscribeNamespaceStore = namespaceStore.subscribe(store => {
       panelWindow.updateNamespaces(store)
     })
-
-    removeThemeChangeListener = () => {
-      browser.devtools.panels.onThemeChanged.removeListener(panelWindow.setTheme)
-    }
   })
 
   panel.onHidden.addListener(() => {

--- a/src/devtools/panel.js
+++ b/src/devtools/panel.js
@@ -15,6 +15,11 @@ export const selectedMessageStore = writable(null)
 
 export let clearMessages
 
+// called from devtools.js in onshown
+function setTheme(theme) {
+  console.log('called setTheme', theme)
+}
+
 function initializeStores(data) {
   connectionStore.set(data.connection)
   messageStore.set(data.messages)
@@ -40,6 +45,7 @@ window.initializeStores = initializeStores
 window.updateConnection = updateConnection
 window.updateMessages = updateMessages
 window.updateNamespaces = updateNamespaces
+window.setTheme = setTheme
 
 
 // RENDER PANEL


### PR DESCRIPTION
Updated devtools.js and panel.js to detect and react to browser devtools theme changes. Currently this calls a function in panel.js in panel / onShown that logs to the console. @bgins unsure what the right approach is to implement light / dark themes in the UI?

