### PR TITLE
Update integration with ODD SDK

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,5 +1,5 @@
-if (!window.webnativeMessageHandlerInjected) {
-  window.webnativeMessageHandlerInjected = true
+if (!window.oddMessageHandlerInjected) {
+  window.oddMessageHandlerInjected = true
 
   window.addEventListener('message', (event) => {
     // Reject messages not from ourselves

--- a/src/content/page-load.js
+++ b/src/content/page-load.js
@@ -4,7 +4,7 @@ window.addEventListener('message', (event) => {
   // Reject messages not from ourselves
   if (event.source !== window) return
 
-  if (event.data.id === 'webnative-devtools-ready-message') {
+  if (event.data.id === 'odd-devtools-ready-message') {
     chrome.runtime.sendMessage({ id: `${chrome.runtime.id}`, type: 'ready' })
   }
 })

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -96,8 +96,8 @@ export async function connect() {
   console.log('connecting to Webnative')
 
   const [connecting, err] = await browser.devtools.inspectedWindow.eval(`
-    if (window.__webnative?.extension) {
-      window.__webnative.extension.connect('${chrome.runtime.id}')
+    if (window.__odd?.extension) {
+      window.__odd.extension.connect('${chrome.runtime.id}')
       true
     } else {
       false
@@ -116,8 +116,8 @@ export async function disconnect() {
   console.log('disconnecting from Webnative')
 
   const [disconnecting, err] = await browser.devtools.inspectedWindow.eval(`
-    if (window.__webnative?.extension) {
-      window.__webnative.extension.disconnect('${chrome.runtime.id}')
+    if (window.__odd?.extension) {
+      window.__odd.extension.disconnect('${chrome.runtime.id}')
       true
     } else {
       false
@@ -146,7 +146,7 @@ function handleBackgroundMessage(message) {
 
     const namespace = {
       namespace: namespaceToString(message.state.app.namespace),
-      version: message.state.webnative.version
+      version: message.state.odd.version
     }
     namespaceStore.update(store =>
       [...store.filter(ns => ns.namespace !== namespaceToString(message.state.app.namespace)), namespace]

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -161,8 +161,8 @@ function handleBackgroundMessage(message) {
     console.log('received session message', message)
 
     messageStore.update(history => [...history, message])
-  } else if (message.type === 'filesystem') {
-    console.log('received filesystem message', message)
+  } else if (message.type === 'fileSystem') {
+    console.log('received file system message', message)
 
     messageStore.update(history => [...history, message])
   } else if (message.type === 'pageload') {

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,7 +1,7 @@
 import type { AppInfo } from '../namespace'
 
 export type Message = {
-  type: 'session' | 'filesystem'
+  type: 'session' | 'fileSystem'
   timestamp: number
   state: State
   detail: Detail
@@ -13,7 +13,7 @@ type State = {
     namespace: AppInfo | string
     capabilities?: Permissions
   }
-  filesystem: {
+  fileSystem: {
     dataRootCID: string | null
   }
   user: {
@@ -33,7 +33,7 @@ export function label(message: Message): string {
   let label
 
   switch (message.type) {
-    case 'filesystem':
+    case 'fileSystem':
       if (message.detail.type === 'local-change') {
         label = 'Local Change'
       } else {


### PR DESCRIPTION
# Description

The PR implements the following changes:

- [x] Rename integration points from webnative to odd
- [x] Rename `filesystem` to `fileSystem`


## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

The changes must be tested with an app that uses Webnative on the [add-browser-extension-support](https://github.com/fission-codes/webnative/tree/add-browser-extension-support) branch.

Follow the instructions in the README to temporarily install the extension. Navigate to an app that uses Webnative and open the Webnative devtools panel.

All events should be displayed as before, but the event payload will contain a field that has been updated from `filesystem` to `fileSystem`.
