### PR TITLE
Downgrade Firefox extension to MV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2023-03-10
 
 ### Fixed
 
-- Firefox incorrectly displays not connected view. Increased connection check timeout.
+- Firefox incorrectly displays not connected view. Increased connection check timeout
 
 ### Changed
 
-- Rearrange state in event payload to present information more clearly and remove redundancy.
+- Rearrange state in event payload to present information more clearly and remove redundancy
+- Downgrade Firefox extension to Manifest V2
 
 ## [0.1.0] - 2023-03-05
 

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
   "description": "Developer tools for debugging ODD applications.",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "ODD Devtools",
   "version": "0.2.0",
   "developer": {
@@ -27,21 +27,14 @@
     }
   ],
   "devtools_page": "src/devtools/devtools.html",
-  "host_permissions": [
+  "permissions": [
+    "scripting",
     "https://*/*",
     "http://localhost/*",
     "http://127.0.0.1/*"
   ],
-  "permissions": [
-    "scripting"
-  ],
   "web_accessible_resources": [
-    {
-      "resources": [
-        "src/content/content.js"
-      ],
-      "matches": ["https://*/*"]
-    }
+    "src/content/content.js"
   ],
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Downgrade Firefox extension to Manifest V2

When using Manifest V3 in Firefox, host permissions are optional by default. A user isn't prompted to grant permission when they install the extension. Instead, they must grant permissions from `about:addons`.

To address this, we have considered displaying an error page with a link to an options page where they could grant permissions: https://github.com/oddsdk/odd-devtools/issues/44#issuecomment-1540553218. This approach has less than ideal UX, which might leave users wondering why they needed to visit a special page to grant permission.

Manifest V2 prompts the user for the necessary permission at install time. This approach is simpler and better for now, but we will want to come back to Manifest V3 at some point when the dust has settled. We are discussing these issues with the extension community in a couple of forums: https://github.com/oddsdk/odd-devtools/issues/44#issuecomment-1536807525

## Link to issue

Closes #44

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Build the extension and test it in Firefox. It should not be necessary to enable optional host permissions in `about:addons`
